### PR TITLE
Inclui instrução para reiniciar a cor do console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,11 +14,7 @@ namespace ContagemRegressiva
             Console.ReadKey();
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine("Fogo!");
-            Console.ForegroundColor = ConsoleColor.White;
-
-
-
-
+            Console.ResetColor();
 
         }
 


### PR DESCRIPTION
Uso de Console.ResetColor(); é preferível ao invés de Console.ForegroundColor = ConsoleColor.White;

A cor padrão da fonte do usuário pode não ser branca.